### PR TITLE
Remove `-xcargs` option and fix extra escaping around xcargs

### DIFF
--- a/lib/gym/build_command_generator.rb
+++ b/lib/gym/build_command_generator.rb
@@ -40,7 +40,7 @@ module Gym
         options << "-sdk '#{config[:sdk]}'" if config[:sdk]
         options << "-destination '#{config[:destination]}'" if config[:destination]
         options << "-archivePath '#{archive_path}'"
-        options << "-xcargs '#{config[:xcargs]}'" if config[:xcargs]
+        options << config[:xcargs] if config[:xcargs]
 
         options
       end

--- a/lib/gym/options.rb
+++ b/lib/gym/options.rb
@@ -101,7 +101,7 @@ module Gym
         FastlaneCore::ConfigItem.new(key: :xcargs,
                                      short_option: "-x",
                                      env_name: "GYM_XCARGS",
-                                     description: "Pass additional arguments to xcodebuild when building the app. Be sure to quote multiple args",
+                                     description: "Pass additional arguments to xcodebuild when building the app. Be sure to quote the setting names and values e.g. OTHER_LDFLAGS=\"-ObjC -lstdc++\"",
                                      optional: true)
 
       ]

--- a/spec/build_command_generator_spec.rb
+++ b/spec/build_command_generator_spec.rb
@@ -1,3 +1,5 @@
+require "shellwords"
+
 describe Gym do
   describe Gym::BuildCommandGenerator do
     it "raises an exception when project path wasn't found" do
@@ -7,7 +9,11 @@ describe Gym do
     end
 
     it "supports additional parameters" do
-      options = { project: "./example/standard/Example.xcodeproj", sdk: "9.0" }
+      xcargs_hash = { DEBUG: "1", BUNDLE_NAME: "Example App" }
+      xcargs = xcargs_hash.map do |k, v|
+        "#{k.to_s.shellescape}=#{v.shellescape}"
+      end.join ' '
+      options = { project: "./example/standard/Example.xcodeproj", sdk: "9.0", xcargs: xcargs }
       Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
 
       result = Gym::BuildCommandGenerator.generate
@@ -20,6 +26,7 @@ describe Gym do
         "-sdk '9.0'",
         "-destination 'generic/platform=iOS'",
         "-archivePath '#{Gym::BuildCommandGenerator.archive_path}'",
+        "DEBUG=1 BUNDLE_NAME=Example\\ App",
         :archive,
         "| xcpretty"
       ])


### PR DESCRIPTION
xcodebuild does not take an -xcargs option since it just takes the key-value pairs directly.

Also multiple key-value pairs need to be provided separately in the command, instead of having quotes around all of them (e.g. `A=1 B=2` instead of `'A=1 B=2'`) so I removed the quoting. This matches the behavior of shenzhen, and my Fastfile that worked with ipa/shenzhen now works with gym with little modification. Since no one could have been relying on xcargs with gym before this commit, I don't think this change should disrupt anyone.

Fixes #15, updated test passes