### PR TITLE
Make sure invalid configurations are detected

### DIFF
--- a/spec/commands_generator_spec.rb
+++ b/spec/commands_generator_spec.rb
@@ -1,0 +1,9 @@
+require "gym/commands_generator"
+
+describe Gym do
+  describe Gym::CommandsGenerator do
+    it "validates available_options" do
+      # this runs the initialization code in the commands generator and detects invalid options
+    end
+  end
+end


### PR DESCRIPTION
Found out why gym didn't detect the duplicate option the other day. Adding a test.
If this pattern of initialization the options is used on all fastlane tools, wonder if there shouldn't be a better way to check that.