### PR TITLE
Fix: Reference `gym` instead of `pilot`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,14 @@
 
 Before submitting a new issue, do the following:
 
-- Verify you're runing the latest version by running `pilot -v` and compare it with the [project page on GitHub](https://github.com/fastlane/pilot).
+- Verify you're runing the latest version by running `gym -v` and compare it with the [project page on GitHub](https://github.com/fastlane/gym).
 - Verify you have Xcode tools installed by running `xcode-select --install`.
-- Make sure to read through the [README](https://github.com/KrauseFx/pilot) of the project.
+- Make sure to read through the [README](https://github.com/fastlane/gym) of the project.
 
 
 When submitting a new issue, please provide the following information:
 
-- The full stack trace and output when running `pilot`.
+- The full stack trace and output when running `gym`.
 - The command and parameters you used to launch it.
 
 ### By providing this information it's much faster and easier to help you


### PR DESCRIPTION
This file was still referencing `pilot` instead of `gym`.