### PR TITLE
Change dSYM extension to be case-sensitive.

### DIFF
--- a/lib/gym/package_command_generator.rb
+++ b/lib/gym/package_command_generator.rb
@@ -54,7 +54,7 @@ module Gym
 
       # The path the the dsym file for this app. Might be nil
       def dsym_path
-        Dir[BuildCommandGenerator.archive_path + "/**/*.dsym"].last
+        Dir[BuildCommandGenerator.archive_path + "/**/*.dSYM"].last
       end
     end
   end


### PR DESCRIPTION
This fixed #31 for me. The dSYM file was copied along with the ipa, both when an 'output_directory' was specified and when it was not.