### PR TITLE
Creates output_directory if it doesn't exist

### DIFF
--- a/lib/gym/options.rb
+++ b/lib/gym/options.rb
@@ -49,10 +49,7 @@ module Gym
                                      short_option: "-o",
                                      env_name: "GYM_OUTPUT_DIRECTORY",
                                      description: "The directory in which the ipa file should be stored in",
-                                     default_value: ".",
-                                     verify_block: proc do |value|
-                                       raise "Directory not found at path '#{File.expand_path(value)}'".red unless File.directory?(value)
-                                     end),
+                                     default_value: "."),
         FastlaneCore::ConfigItem.new(key: :output_name,
                                      short_option: "-n",
                                      env_name: "GYM_OUTPUT_NAME",

--- a/lib/gym/runner.rb
+++ b/lib/gym/runner.rb
@@ -91,7 +91,8 @@ module Gym
     # @return (String) The path to the resulting ipa file
     def move_results
       require 'fileutils'
-
+      
+      FileUtils.mkdir_p(Gym.config[:output_directory])
       FileUtils.mv(PackageCommandGenerator.ipa_path, Gym.config[:output_directory], force: true)
 
       if PackageCommandGenerator.dsym_path

--- a/lib/gym/runner.rb
+++ b/lib/gym/runner.rb
@@ -91,7 +91,6 @@ module Gym
     # @return (String) The path to the resulting ipa file
     def move_results
       require 'fileutils'
-      
       FileUtils.mkdir_p(Gym.config[:output_directory])
       FileUtils.mv(PackageCommandGenerator.ipa_path, Gym.config[:output_directory], force: true)
 


### PR DESCRIPTION
* removes check for the config_item if the folder exists
* adds mkdir_p command for the output_directory in move_results:runner.rb