### PR TITLE
Fix hang when no schemes are found

### DIFF
--- a/lib/gym/detect_values.rb
+++ b/lib/gym/detect_values.rb
@@ -121,7 +121,9 @@ module Gym
           config[:scheme] = choose(*(proj_schemes))
         end
       else
-        raise "Couldn't find any schemes in this project".red
+        Helper.log.error "Couldn't find any schemes in this project, make sure that the scheme is shared if you are using a workspace".red
+
+        raise "No Schemes found".red
       end
     end
 

--- a/lib/gym/project.rb
+++ b/lib/gym/project.rb
@@ -19,6 +19,7 @@ module Gym
     def schemes
       results = []
       output = raw_info.split("Schemes:").last.split(":").first
+      return results if is_workspace && output.start_with?("There are no schemes in workspace")
       output.split("\n").each do |current|
         current = current.strip
 


### PR DESCRIPTION
I ran into an issue where fastlane was selecting an error message as the scheme, and then trying to build  with the scheme set to the error message!

```
[09:16:40]: --- Step: gym ---
[09:16:40]: -----------------
[09:16:40]: xcrun xcodebuild -list -workspace './XXXXXXXXXXXXX.xcworkspace'
[09:16:41]: Couldn't find specified scheme 'XXXXXXXXXXXXX'.
[09:16:41]: xcrun xcodebuild -showBuildSettings -workspace './XXXXXXXXX.xcworkspace' -scheme 'There are no schemes in workspace "XXXXXXXXXXXXX".'
```
That last xcrun command would hang indefinitely.

The fix checks for the error message in project.rb and returns an empty array if the error message is seen. Also, detect_values.rb adds an error message with the probable fix -- share the scheme in your workspace.

Thanks for the awesome tool!
