### PR TITLE
Fix crash with apostrophes in product name

### DIFF
--- a/lib/gym/package_command_generator.rb
+++ b/lib/gym/package_command_generator.rb
@@ -16,7 +16,7 @@ module Gym
       def options
         options = []
 
-        options << "'#{appfile_path}'"
+        options << Shellwords.escape(appfile_path)
         options << "-o '#{ipa_path}'"
         options << "exportFormat ipa"
 

--- a/spec/package_command_generator_spec.rb
+++ b/spec/package_command_generator_spec.rb
@@ -29,6 +29,5 @@ describe Gym do
         ""
       ])
     end
-
   end
 end

--- a/spec/package_command_generator_spec.rb
+++ b/spec/package_command_generator_spec.rb
@@ -13,5 +13,22 @@ describe Gym do
         ""
       ])
     end
+
+    it "works with the example project with no additional parameters and an apostrophe/single quote in the product name" do
+      options = { project: "./examples/standard/Example.xcodeproj" }
+      Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+      allow(Gym::PackageCommandGenerator).to receive(:appfile_path).and_return("Krause's App")
+
+      result = Gym::PackageCommandGenerator.generate
+      expect(result).to eq([
+        "/usr/bin/xcrun /tmp/PackageApplication4Gym -v",
+        Shellwords.escape("Krause's App"),
+        "-o '#{Gym::PackageCommandGenerator.ipa_path}'",
+        "exportFormat ipa",
+        ""
+      ])
+    end
+
   end
 end


### PR DESCRIPTION
A single quote in the product name was the reason for a crash during packaging:
```sh
/usr/bin/xcrun /tmp/PackageApplication4Gym -v '...path to product's name.app'
```
I had to quickly fix this, since I cannot change the product name.
It is working for me now.