### PR TITLE
Change sdk in GymfileTemplate

### DIFF
--- a/lib/assets/GymfileTemplate
+++ b/lib/assets/GymfileTemplate
@@ -9,6 +9,6 @@
 
 # scheme "Example"
 
-# sdk "9.0"
+# sdk "iphoneos9.0"
 
 output_directory "./"


### PR DESCRIPTION
xcodebuild does not think 9.0 is a valid value, but it does like iphoneos9.0