### PR TITLE
Generate xcodebuild.log for more details

### DIFF
--- a/lib/gym/generators/build_command_generator.rb
+++ b/lib/gym/generators/build_command_generator.rb
@@ -63,7 +63,7 @@ module Gym
       end
 
       def pipe
-        ["| xcpretty"]
+        ["| tee 'xcodebuild-#{Gym.config[:scheme]}.log' | xcpretty"]
       end
 
       # The path to set the Derived Data to

--- a/spec/build_command_generator_spec.rb
+++ b/spec/build_command_generator_spec.rb
@@ -26,7 +26,7 @@ describe Gym do
         "-archivePath '#{Gym::BuildCommandGenerator.archive_path}'",
         "DEBUG=1 BUNDLE_NAME=Example\\ App",
         :archive,
-        "| xcpretty"
+        "| tee 'xcodebuild-Example.log' | xcpretty"
       ])
     end
 
@@ -47,7 +47,7 @@ describe Gym do
           "-destination 'generic/platform=iOS'",
           "-archivePath '#{Gym::BuildCommandGenerator.archive_path}'",
           :archive,
-          "| xcpretty"
+          "| tee 'xcodebuild-Example.log' | xcpretty"
         ])
       end
 


### PR DESCRIPTION
Create xcodebuild.log file containing detailed xcodebuild output.
This is very useful for debugging.
The implementation is simple, it creates xcodebuild-SchemeName.log file.

