### PR TITLE
Added buildlog_path option to change the location of the xcodebuild logs

### DIFF
--- a/lib/gym/generators/build_command_generator.rb
+++ b/lib/gym/generators/build_command_generator.rb
@@ -68,7 +68,9 @@ module Gym
 
       def xcodebuild_log_path
         file_name = "#{Gym.project.app_name}-#{Gym.config[:scheme]}.log"
-        containing = File.expand_path("~/Library/Logs/gym")
+        file_dir = Gym.config[:buildlog_path]
+        file_dir ||= "~/Library/Logs/gym"
+        containing = File.expand_path(file_dir)
         FileUtils.mkdir_p(containing)
 
         return File.join(containing, file_name)

--- a/lib/gym/generators/build_command_generator.rb
+++ b/lib/gym/generators/build_command_generator.rb
@@ -68,9 +68,7 @@ module Gym
 
       def xcodebuild_log_path
         file_name = "#{Gym.project.app_name}-#{Gym.config[:scheme]}.log"
-        file_dir = Gym.config[:buildlog_path]
-        file_dir ||= "~/Library/Logs/gym"
-        containing = File.expand_path(file_dir)
+        containing = File.expand_path(Gym.config[:buildlog_path])
         FileUtils.mkdir_p(containing)
 
         return File.join(containing, file_name)

--- a/lib/gym/options.rb
+++ b/lib/gym/options.rb
@@ -63,6 +63,11 @@ module Gym
                                      verify_block: proc do |value|
                                        value.gsub!(".ipa", "")
                                      end),
+        FastlaneCore::ConfigItem.new(key: :buildlog_path,
+                                     short_option: "-l",
+                                     env_name: "GYM_BUILDLOG_PATH",
+                                     description: "The directory were to store the build log",
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :sdk,
                                      short_option: "-k",
                                      env_name: "GYM_SDK",

--- a/lib/gym/options.rb
+++ b/lib/gym/options.rb
@@ -67,7 +67,7 @@ module Gym
                                      short_option: "-l",
                                      env_name: "GYM_BUILDLOG_PATH",
                                      description: "The directory were to store the build log",
-                                     optional: true),
+                                     default_value: "~/Library/Logs/gym"),
         FastlaneCore::ConfigItem.new(key: :sdk,
                                      short_option: "-k",
                                      env_name: "GYM_SDK",

--- a/spec/build_command_generator_spec.rb
+++ b/spec/build_command_generator_spec.rb
@@ -71,6 +71,18 @@ describe Gym do
         regex = %r{Library/Developer/Xcode/Archives/\d\d\d\d\-\d\d\-\d\d/ExampleProductName \d\d\d\d\-\d\d\-\d\d \d\d\.\d\d\.\d\d.xcarchive}
         expect(result).to match(regex)
       end
+
+      it "#buildlog_path is used when provided" do
+        options = { project: "./examples/standard/Example.xcodeproj", buildlog_path: "/tmp/my/path" }
+        Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+        result = Gym::BuildCommandGenerator.xcodebuild_log_path
+        expect(result).to include("/tmp/my/path")
+      end
+
+      it "#buildlog_path is not used when not provided" do
+        result = Gym::BuildCommandGenerator.xcodebuild_log_path
+        expect(result.to_s).to include("Library/Logs/gym")
+      end
     end
   end
 end


### PR DESCRIPTION
Added option ```buildlog_path``` to change the location of the xcodebuild log. By default it is ```~/Library/Logs/gym```.

If ```buildlog_path``` is set to ```/my/location```, then the final build log will end up to ```/my/location``` folder instead of ```~/Library/Logs/gym```.

This is useful in specific cases when it is desired to have to build log file in a different location.