### PR TITLE
Add newer versions of Ruby for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: objective-c
 osx_image: xcode6.4
-before_install: gem update --system
+before_install:
+  - gem update --system
+  - gem install bundler
 rvm:
   - 2.0.0
+  - 2.1.7
+  - 2.2.3
 script: bundle exec fastlane test


### PR DESCRIPTION
I've noticed that you tried to add these Rubies for Travis in past but it didn't work well, I think the problem was only with not installed bundler.