### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Run `gym init` to create a new configuration file. Example:
 ```ruby
 scheme "Example"
 
-sdk "9.0"
+sdk "iphoneos9.0"
 
 clean true
 


### PR DESCRIPTION
Fix the broken example Gymfile's "9.0" SDK.

(I wish I'd used `gym init` instead of copying and pasting this example.)