### PR TITLE
Fix for issue #115, 'Generated archive is invalid'

### DIFF
--- a/lib/gym/generators/build_command_generator.rb
+++ b/lib/gym/generators/build_command_generator.rb
@@ -86,6 +86,9 @@ module Gym
           file_name = [Gym.config[:output_name], Time.now.strftime("%F %H.%M.%S")] # e.g. 2015-08-07 14.49.12
           Gym.cache[:archive_path] = File.join(build_path, file_name.join(" ") + ".xcarchive")
         end
+        if File.extname(Gym.cache[:archive_path]) != ".xcarchive"
+          Gym.cache[:archive_path] += ".xcarchive"
+        end
         return Gym.cache[:archive_path]
       end
     end

--- a/lib/gym/runner.rb
+++ b/lib/gym/runner.rb
@@ -87,7 +87,7 @@ module Gym
     # Makes sure the archive is there and valid
     def verify_archive
       # from https://github.com/fastlane/gym/issues/115
-      if (Dir[BuildCommandGenerator.archive_path + "/*"] + Dir[BuildCommandGenerator.archive_path + ".xcarchive/*"]).count == 0
+      if (Dir[BuildCommandGenerator.archive_path + "/*"]).count == 0
         ErrorHandler.handle_empty_archive
       end
     end


### PR DESCRIPTION
This pull request solves the problem with the generated archive being reported as invalid by gym even when it wasn't. 

The problem was that the `BuildCommandsGenerator.archive_path` was assumed to always have the extension ".xcarchive". This pull request adds the extension onto the `archive_path` if it wasn't the extension already 