### PR TITLE
Mention --export_method in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ In general, if you run into issues while exporting the archive, try using:
 
     gym --use_legacy_build_api true
 
+Set the right export method if you're not uploading to App Store or TestFlight:
+
+    gym --export_method ad-hoc
+
 To pass boolean parameters make sure to use `gym` like this:
 
     gym --include_bitcode true --include_symbols false


### PR DESCRIPTION
Document that `--export_method` should be passed if you want an AdHoc (or any non-AppStore/TF) build.

Took me like two hours to figure out how to make the new Xcode export API work, battling Gym, and trying to decipher error logs, just to realize (after peeking into the export configuration plist) that Gym defaults the export method to "app-store".

AdHoc builds are still pretty common, so it's worth documenting it right on the front page IMHO.