### PR TITLE
Added Fix for WatchKit 2.0 Support. (Apple Should fix their build chain)

### DIFF
--- a/lib/gym.rb
+++ b/lib/gym.rb
@@ -34,6 +34,7 @@ module Gym
       # Import all the fixes
       require 'gym/xcodebuild_fixes/swift_fix'
       require 'gym/xcodebuild_fixes/watchkit_fix'
+      require 'gym/xcodebuild_fixes/watchkit2_fix'
       require 'gym/xcodebuild_fixes/package_application_fix'
     end
   end

--- a/lib/gym/runner.rb
+++ b/lib/gym/runner.rb
@@ -67,6 +67,7 @@ module Gym
       return unless Gym.config[:use_legacy_build_api]
       Gym::XcodebuildFixes.swift_library_fix
       Gym::XcodebuildFixes.watchkit_fix
+      Gym::XcodebuildFixes.watchkit2_fix
     end
 
     # Builds the app and prepares the archive

--- a/lib/gym/xcodebuild_fixes/watchkit2_fix.rb
+++ b/lib/gym/xcodebuild_fixes/watchkit2_fix.rb
@@ -1,0 +1,35 @@
+module Gym
+  class XcodebuildFixes
+    class << self
+      # Determine whether this app has WatchKit2 support and manually package up the WatchKit2 framework
+      def watchkit2_fix
+        return unless watchkit2?
+
+        Helper.log.info "Adding WatchKit2 support" if $verbose
+
+        Dir.mktmpdir do |tmpdir|
+          # Make watchkit support directory
+          watchkit_support = File.join(tmpdir, "WatchKitSupport2")
+          Dir.mkdir(watchkit_support)
+
+          # Copy WK from Xcode into WatchKitSupport2
+          FileUtils.copy_file("#{Xcode.xcode_path}/Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk/Library/Application Support/WatchKit/WK", File.join(watchkit_support, "WK"))
+
+          # Add "WatchKitSupport2" to the .ipa archive
+          Dir.chdir(tmpdir) do
+            abort unless system %(zip --recurse-paths "#{PackageCommandGenerator.ipa_path}" "WatchKitSupport2" > /dev/null)
+          end
+
+          Helper.log.info "Successfully added WatchKit2 support" if $verbose
+        end
+      end
+
+      # Does this application have a WatchKit target
+      def watchkit2?
+        Dir["#{PackageCommandGenerator.appfile_path}/**/*.plist"].any? do |plist_path|
+          `/usr/libexec/PlistBuddy -c 'Print DTSDKName' '#{plist_path}' 2>&1`.strip == 'watchos2.0'
+        end
+      end
+    end
+  end
+end

--- a/lib/gym/xcodebuild_fixes/watchkit_fix.rb
+++ b/lib/gym/xcodebuild_fixes/watchkit_fix.rb
@@ -28,7 +28,7 @@ module Gym
       def watchkit?
         Dir["#{PackageCommandGenerator.appfile_path}/**/*.plist"].any? do |plist_path|
           `/usr/libexec/PlistBuddy -c 'Print WKWatchKitApp' '#{plist_path}' 2>&1`.strip == 'true'
-        end
+        end && !(Gym::XcodebuildFixes.watchkit2?)
       end
     end
   end

--- a/lib/gym/xcodebuild_fixes/watchkit_fix.rb
+++ b/lib/gym/xcodebuild_fixes/watchkit_fix.rb
@@ -3,7 +3,7 @@ module Gym
     class << self
       # Determine whether this app has WatchKit support and manually package up the WatchKit framework
       def watchkit_fix
-        return unless watchkit?
+        return unless should_apply_watchkit1_fix?
 
         Helper.log.info "Adding WatchKit support" if $verbose
 
@@ -28,7 +28,12 @@ module Gym
       def watchkit?
         Dir["#{PackageCommandGenerator.appfile_path}/**/*.plist"].any? do |plist_path|
           `/usr/libexec/PlistBuddy -c 'Print WKWatchKitApp' '#{plist_path}' 2>&1`.strip == 'true'
-        end && !(Gym::XcodebuildFixes.watchkit2?)
+        end
+      end
+
+      # Should only be applied if watchkit app is not a watchkit2 app
+      def should_apply_watchkit1_fix?
+        watchkit? && !(Gym::XcodebuildFixes.watchkit2?)
       end
     end
   end


### PR DESCRIPTION
Nearly the same like the WatchOS 1 fix. I also adapted the WatchOS 1 hack, because it's also failing if you have both Support folders in the binary. Currently it's only working for the one or the other, not both. I don't know if that's a real use case. I also checked a WatchOS 1 plist and didn't find any other way to detect WatchOS 1.

Uploaded WatchOS2 to iTC without any issues ☕️