### PR TITLE
Add option to suppress xcodebuild output

### DIFF
--- a/lib/gym/generators/build_command_generator.rb
+++ b/lib/gym/generators/build_command_generator.rb
@@ -58,7 +58,11 @@ module Gym
       end
 
       def pipe
-        ["| tee '#{xcodebuild_log_path}' | xcpretty"]
+        pipe = []
+        pipe << "| tee '#{xcodebuild_log_path}' | xcpretty"
+        pipe << "> /dev/null" if Gym.config[:suppress_xcode_output]
+
+        pipe
       end
 
       def xcodebuild_log_path

--- a/lib/gym/options.rb
+++ b/lib/gym/options.rb
@@ -159,7 +159,7 @@ module Gym
                                      description: "Suppress the output of xcodebuild to stdout. Output is still saved in buildlog_path",
                                      optional: true,
                                      is_string: false
-                                     )
+                                    )
       ]
     end
   end

--- a/lib/gym/options.rb
+++ b/lib/gym/options.rb
@@ -152,7 +152,14 @@ module Gym
                                      optional: true,
                                      verify_block: proc do |value|
                                        raise "File not found at path '#{File.expand_path(value)}'".red unless File.exist?(value)
-                                     end)
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :suppress_xcode_output,
+                                     short_option: "-r",
+                                     env_name: "SUPPRESS_OUTPUT",
+                                     description: "Suppress the output of xcodebuild to stdout. Output is still saved in buildlog_path",
+                                     optional: true,
+                                     is_string: false
+                                     )
       ]
     end
   end


### PR DESCRIPTION
We are using gym in our ci set up teamcity, and with the output from xcodebuild even with xcpretty on chrome doesn't load or takes forever to load the build log. A lot of the times the build completes but code signing fails or something like that. So it would be nice to suppress all xcode compile output and only keep the fastlane stuff.
We can still get to the log on the build agent if needed.

Not sure if this is the best approach, but a quick solution. If you can think of a better way that would be awesome.