### PR TITLE
Disable colors in xcpretty when FASTLANE_DISABLE_COLORS is set

### DIFF
--- a/lib/gym/generators/build_command_generator.rb
+++ b/lib/gym/generators/build_command_generator.rb
@@ -60,6 +60,7 @@ module Gym
       def pipe
         pipe = []
         pipe << "| tee '#{xcodebuild_log_path}' | xcpretty"
+        pipe << "--no-color" if ENV["FASTLANE_DISABLE_COLORS"]
         pipe << "> /dev/null" if Gym.config[:suppress_xcode_output]
 
         pipe


### PR DESCRIPTION
Basically, the same fix as [here](https://github.com/fastlane/scan/pull/63).
It disables xcpretty colored output when `FASTLANE_DISABLE_COLORS ` env variable is set.