### PR TITLE
Fixed issue with creating ipa and dsym for tvos

### DIFF
--- a/lib/gym/runner.rb
+++ b/lib/gym/runner.rb
@@ -12,7 +12,7 @@ module Gym
 
       FileUtils.mkdir_p(Gym.config[:output_directory])
 
-      if Gym.project.ios?
+      if Gym.project.ios? || Gym.project.tvos?
         package_app
         fix_package
         compress_and_move_dsym


### PR DESCRIPTION
Hey @KrauseFx,

I was trying to build my tvos project with `gym`, but for some reason, no ipa was being generated.
After some debugging, I found this file. Adding the line made the ipa and dsym generates for me. I haven't tested any other scenario with this fix.

The tests pass (26 examples, 0 failures). I tried writing a test for this, but I couldn't quickly think of something that doesn't involve xcodebuild.

Please let me know if you'd like me to check more cases or update something else.