### PR TITLE
Issue #168 wrap xcodebuild calls within ruby system environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ After building the archive it is being checked by `gym`. If it's valid, it gets 
 ### Xcode 7 and above
 
 ```
-/usr/bin/xcrun xcodebuild -exportArchive \
+/usr/bin/xcrun path/to/xcbuild-safe.sh -exportArchive \
 -exportOptionsPlist '/tmp/gym_config_1442852529.plist' \
 -archivePath '/Users/fkrause/Library/Developer/Xcode/Archives/2015-09-21/App 2015-09-21 09.21.56.xcarchive' \
 -exportPath '/tmp/1442852529'
@@ -213,6 +213,8 @@ After building the archive it is being checked by `gym`. If it's valid, it gets 
 `gym` makes use of the new Xcode 7 API which allows us to specify the export options using a `plist` file. You can find more information about the available options by running `xcodebuild --help`.
 
 Using this method there are no workarounds for WatchKit or Swift required, as it uses the same technique Xcode uses when exporting your binary.
+
+Note: the [xcbuild-safe.sh script](https://github.com/fastlane/gym/tree/master/lib/assets/wrap_xcodebuild/xcbuild-safe.sh) wraps around xcodebuild to workaround some incompatibilities.
 
 ### Xcode 6 and below
 

--- a/lib/assets/wrap_xcodebuild/xcbuild-safe.sh
+++ b/lib/assets/wrap_xcodebuild/xcbuild-safe.sh
@@ -1,6 +1,7 @@
 #!/bin/bash --login
 
-# Cf. http://stackoverflow.com/questions/33041109
+# Originally from, http://stackoverflow.com/questions/33041109
+# Modified to work in RVM and non RVM environments
 #
 # Xcode 7 (incl. 7.0.1) seems to have a dependency on the system ruby.
 # xcodebuild is screwed up by using rvm to map to another non-system
@@ -20,19 +21,29 @@
 # † Because, you know, that *never* happens when you are building
 # Xcode projects, say with abstruse tools like Rake or CocoaPods.
 
-# This allows you to use rvm in a script. Otherwise you get a BS
-# error along the lines of "cannot use rvm as function". Jeez.
-[[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm"
+which rvm > /dev/null
 
-# Cause rvm to use system ruby. AFAIK, this is effective only for
-# the scope of this script.
-which rvm && rvm use system
+if [[ $? -eq 0 ]]; then
+  echo "RVM detected, forcing to use system ruby"
+  # This allows you to use rvm in a script. Otherwise you get a BS
+  # error along the lines of "cannot use rvm as function". Jeez.
+  [[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm"
+
+  # Cause rvm to use system ruby. AFAIK, this is effective only for
+  # the scope of this script.
+  rvm use system
+
+  # rvm doesn't unset itself properly without doing this
+  unset RUBYLIB
+  unset RUBYOPT
+  unset BUNDLE_BIN_PATH
+  unset _ORIGINAL_GEM_PATH
+  unset BUNDLE_GEMFILE
+fi
+
+# to help troubleshooting
+# env | sort > /tmp/env.wrapper
+# rvm info >> /tmp/env.wrapper
+
 set -x          # echoes commands
-unset RUBYLIB
-unset RUBYOPT
-unset BUNDLE_BIN_PATH
-unset _ORIGINAL_GEM_PATH
-unset BUNDLE_GEMFILE
-#env | sort > /tmp/env.wrapper
-#rvm info >> /tmp/env.wrapper
 xcodebuild "$@" # calls xcodebuild with all the arguments passed to this

--- a/lib/assets/wrap_xcodebuild/xcbuild-safe.sh
+++ b/lib/assets/wrap_xcodebuild/xcbuild-safe.sh
@@ -1,0 +1,38 @@
+#!/bin/bash --login
+
+# Cf. http://stackoverflow.com/questions/33041109
+#
+# Xcode 7 (incl. 7.0.1) seems to have a dependency on the system ruby.
+# xcodebuild is screwed up by using rvm to map to another non-system
+# ruby†. This script is a fix that allows you call xcodebuild in a
+# "safe" rvm environment, but will not (AFAIK) affect the "external"
+# rvm setting.
+#
+# The script is a drop in replacement for your xcodebuild call.
+#
+#   xcodebuild arg1 ... argn
+#
+# would become
+#
+#   path/to/xcbuild-safe.sh arg1 ... argn
+#
+# -----
+# † Because, you know, that *never* happens when you are building
+# Xcode projects, say with abstruse tools like Rake or CocoaPods.
+
+# This allows you to use rvm in a script. Otherwise you get a BS
+# error along the lines of "cannot use rvm as function". Jeez.
+[[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm"
+
+# Cause rvm to use system ruby. AFAIK, this is effective only for
+# the scope of this script.
+which rvm && rvm use system
+set -x          # echoes commands
+unset RUBYLIB
+unset RUBYOPT
+unset BUNDLE_BIN_PATH
+unset _ORIGINAL_GEM_PATH
+unset BUNDLE_GEMFILE
+#env | sort > /tmp/env.wrapper
+#rvm info >> /tmp/env.wrapper
+xcodebuild "$@" # calls xcodebuild with all the arguments passed to this

--- a/lib/gym/generators/package_command_generator_xcode7.rb
+++ b/lib/gym/generators/package_command_generator_xcode7.rb
@@ -10,7 +10,7 @@ module Gym
       def generate
         print_legacy_information unless Helper.fastlane_enabled?
 
-        parts = ["/usr/bin/xcrun xcodebuild -exportArchive"]
+        parts = ["/usr/bin/xcrun #{XcodebuildFixes.wrap_xcodebuild} -exportArchive"]
         parts += options
         parts += pipe
 

--- a/lib/gym/xcodebuild_fixes/package_application_fix.rb
+++ b/lib/gym/xcodebuild_fixes/package_application_fix.rb
@@ -42,6 +42,12 @@ module Gym
 
         return @patched_package_application_path # Return path to the patched PackageApplication
       end
+
+      # Wrap xcodebuild to work-around ipatool dependecy to system ruby
+      def wrap_xcodebuild
+        require 'fileutils'
+        @wrapped_xcodebuild_path ||= File.join(Helper.gem_path("gym"), "lib/assets/wrap_xcodebuild/xcbuild-safe.sh")
+      end
     end
   end
 end

--- a/spec/package_command_generator_xcode7_spec.rb
+++ b/spec/package_command_generator_xcode7_spec.rb
@@ -6,7 +6,7 @@ describe Gym do
 
       result = Gym::PackageCommandGeneratorXcode7.generate
       expect(result).to eq([
-        "/usr/bin/xcrun xcodebuild -exportArchive",
+        "/usr/bin/xcrun #{Gym::XcodebuildFixes.wrap_xcodebuild} -exportArchive",
         "-exportOptionsPlist '#{Gym::PackageCommandGeneratorXcode7.config_path}'",
         "-archivePath '#{Gym::BuildCommandGenerator.archive_path}'",
         "-exportPath '#{Gym::PackageCommandGeneratorXcode7.temporary_output_path}'",


### PR DESCRIPTION
This pull request aims to provide a safe wrapper.

The xcbuild-wrapper.sh originates from a gist linked from a stackoverflow, and was modified to make sure it works when:
1. using rvm
2. using rbenv
3. using system ruby under the following conditions:
```
export GEM_HOME=/Users/lacostej/.gem/ruby/2.0.0
export PATH=/Users/lacostej/.gem/ruby/2.0.0/bin:$PATH
gem install bundler
bundle install
fastlane ...
```
I suspect this is good enough and I don't need to use sudo to test the same thing.