### PR TITLE
Defines prefix in a separate method for PackageCommandGenerators

### DIFF
--- a/lib/gym/generators/package_command_generator_legacy.rb
+++ b/lib/gym/generators/package_command_generator_legacy.rb
@@ -11,11 +11,15 @@ module Gym
   class PackageCommandGeneratorLegacy
     class << self
       def generate
-        parts = ["/usr/bin/xcrun #{XcodebuildFixes.patch_package_application} -v"]
+        parts = prefix
         parts += options
         parts += pipe
 
         parts
+      end
+
+      def prefix
+        ["/usr/bin/xcrun #{XcodebuildFixes.patch_package_application} -v"]
       end
 
       def options

--- a/lib/gym/generators/package_command_generator_xcode7.rb
+++ b/lib/gym/generators/package_command_generator_xcode7.rb
@@ -10,13 +10,17 @@ module Gym
       def generate
         print_legacy_information unless Helper.fastlane_enabled?
 
-        parts = ["/usr/bin/xcrun xcodebuild -exportArchive"]
+        parts = prefix
         parts += options
         parts += pipe
 
         File.write(config_path, config_content) # overwrite everytime. Could be optimized
 
         parts
+      end
+
+      def prefix
+        ["/usr/bin/xcrun xcodebuild -exportArchive"]
       end
 
       def options


### PR DESCRIPTION
To be consistent with [BuildCommandGenerator](https://github.com/fastlane/gym/blob/master/lib/gym/generators/build_command_generator.rb#L5-L18)