### PR TITLE
small change to tempfile name generation

### DIFF
--- a/lib/gym/generators/package_command_generator_xcode7.rb
+++ b/lib/gym/generators/package_command_generator_xcode7.rb
@@ -3,6 +3,8 @@
 # because of
 # `incompatible encoding regexp match (UTF-8 regexp with ASCII-8BIT string) (Encoding::CompatibilityError)`
 
+require 'tempfile'
+
 module Gym
   # Responsible for building the fully working xcodebuild command
   class PackageCommandGeneratorXcode7
@@ -35,7 +37,7 @@ module Gym
 
       # We export the ipa into this directory, as we can't specify the ipa file directly
       def temporary_output_path
-        Gym.cache[:temporary_output_path] ||= File.join("/tmp", Time.now.to_i.to_s)
+        Gym.cache[:temporary_output_path] ||= "#{Tempfile.new('gym').path}.gym_output"
       end
 
       def ipa_path
@@ -56,7 +58,7 @@ module Gym
 
       # The path the config file we use to sign our app
       def config_path
-        Gym.cache[:config_path] ||= "/tmp/gym_config_#{Time.now.to_i}.plist"
+        Gym.cache[:config_path] ||= "#{Tempfile.new('gym').path}_config.plist"
         return Gym.cache[:config_path]
       end
 

--- a/spec/package_command_generator_xcode7_spec.rb
+++ b/spec/package_command_generator_xcode7_spec.rb
@@ -47,7 +47,7 @@ describe Gym do
       Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
 
       result = Gym::PackageCommandGeneratorXcode7.generate
-      expect(Gym::PackageCommandGeneratorXcode7.temporary_output_path).to match(%r{/tmp/\d+})
+      expect(Gym::PackageCommandGeneratorXcode7.temporary_output_path).to match(%r{#{Dir.tmpdir}/gym.+\.gym_output})
     end
   end
 end


### PR DESCRIPTION
Changed the XCode 7 package command generator to use standard Ruby tempfile class to obtain tempfile instead of using /tmp/current_epoch_seconds. 
I was running into tempfile name collision issues while running the build for three different targets concurrently.
A bigger question would be how come gym reaches the packaging stage for three different processes at the exact same second, but I haven't managed to figure that out. My guess is that it's something to do with XCode locking down on something and releasing it.