### PR TITLE
Update `Gym::XcodebuildFixes::watchkit2?` to match watchos2.1

### DIFF
--- a/lib/gym/xcodebuild_fixes/watchkit2_fix.rb
+++ b/lib/gym/xcodebuild_fixes/watchkit2_fix.rb
@@ -27,7 +27,7 @@ module Gym
       # Does this application have a WatchKit target
       def watchkit2?
         Dir["#{PackageCommandGenerator.appfile_path}/**/*.plist"].any? do |plist_path|
-          `/usr/libexec/PlistBuddy -c 'Print DTSDKName' '#{plist_path}' 2>&1`.strip == 'watchos2.0'
+          `/usr/libexec/PlistBuddy -c 'Print DTSDKName' '#{plist_path}' 2>&1`.match(/^\s*watchos2\.\d+\s*$/)
         end
       end
     end


### PR DESCRIPTION
_WatchKit Fix_ module was not matched as Watch OS 2 application for ipa file that build with Version 7.2 (7C68).

![](https://cloud.githubusercontent.com/assets/18631/12233354/f36a2f7e-b8a9-11e5-8343-2bde5947f27a.png)