### PR TITLE
Use conflicting options mechanism for workspace and project paths

### DIFF
--- a/lib/gym/options.rb
+++ b/lib/gym/options.rb
@@ -21,6 +21,10 @@ module Gym
                                        UI.user_error!("Workspace file not found at path '#{v}'") unless File.exist?(v)
                                        UI.user_error!("Workspace file invalid") unless File.directory?(v)
                                        UI.user_error!("Workspace file is not a workspace, must end with .xcworkspace") unless v.include?(".xcworkspace")
+                                     end,
+                                     conflicting_options: [:project],
+                                     conflict_block: proc do |value|
+                                       UI.user_error!("You can only pass either a 'workspace' or a '#{value.key}', not both")
                                      end),
         FastlaneCore::ConfigItem.new(key: :project,
                                      short_option: "-p",
@@ -32,6 +36,10 @@ module Gym
                                        UI.user_error!("Project file not found at path '#{v}'") unless File.exist?(v)
                                        UI.user_error!("Project file invalid") unless File.directory?(v)
                                        UI.user_error!("Project file is not a project file, must end with .xcodeproj") unless v.include?(".xcodeproj")
+                                     end,
+                                     conflicting_options: [:workspace],
+                                     conflict_block: proc do |value|
+                                       UI.user_error!("You can only pass either a 'project' or a '#{value.key}', not both")
                                      end),
         FastlaneCore::ConfigItem.new(key: :scheme,
                                      short_option: "-s",

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -4,7 +4,7 @@ describe Gym do
       expect do
         options = { project: "./examples/standard/Example.xcodeproj", workspace: "./examples/cocoapods/Example.xcworkspace" }
         Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
-      end.to raise_error "You can only pass either a workspace or a project path, not both".red
+      end.to raise_error "You can only pass either a 'project' or a 'workspace', not both"
     end
 
     it "removes the `ipa` from the output name if given" do


### PR DESCRIPTION
In this PR  I added [new mechanism](https://github.com/fastlane/deliver/pull/545) for handling conflicts between `workspace` and `project` options + updated specs.

Feedback and comments are greatly appreciated :smiley_cat: