### PR TITLE
Added `build_path` option

### DIFF
--- a/lib/gym/generators/build_command_generator.rb
+++ b/lib/gym/generators/build_command_generator.rb
@@ -78,8 +78,9 @@ module Gym
         return File.join(containing, file_name)
       end
 
-      # The path to set the Derived Data to
+      # The path where archive will be created
       def build_path
+        Gym.cache[:build_path] ||= Gym.config[:build_path]
         unless Gym.cache[:build_path]
           day = Time.now.strftime("%F") # e.g. 2015-08-07
 

--- a/lib/gym/options.rb
+++ b/lib/gym/options.rb
@@ -124,10 +124,14 @@ module Gym
                                      end),
 
         # Very optional
+        FastlaneCore::ConfigItem.new(key: :build_path,
+                                     env_name: "GYM_BUILD_PATH",
+                                     description: "The directory in which the archive should be stored in",
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :archive_path,
                                      short_option: "-b",
                                      env_name: "GYM_ARCHIVE_PATH",
-                                     description: "The directory in which the archive file should be stored in",
+                                     description: "The path to the created archive",
                                      optional: true),
         FastlaneCore::ConfigItem.new(key: :derived_data_path,
                                      short_option: "-f",

--- a/spec/build_command_generator_spec.rb
+++ b/spec/build_command_generator_spec.rb
@@ -58,10 +58,17 @@ describe Gym do
         expect(result).to eq(["-scheme 'Example'", "-project './examples/standard/Example.xcodeproj'"])
       end
 
-      it "#build_path" do
+      it "default #build_path" do
         result = Gym::BuildCommandGenerator.build_path
         regex = %r{Library/Developer/Xcode/Archives/\d\d\d\d\-\d\d\-\d\d}
         expect(result).to match(regex)
+      end
+
+      it "user provided #build_path" do
+        options = { project: "./examples/standard/Example.xcodeproj", build_path: "/tmp/my/build_path" }
+        Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+        result = Gym::BuildCommandGenerator.build_path
+        expect(result).to eq("/tmp/my/build_path")
       end
 
       it "#archive_path" do


### PR DESCRIPTION
Hi,

The `:archive_path` options it the full path to the xcarchive bundle. Sometimes it is useful to provide path to the directory where xcarchive will be stored (without archive name). That is why I've added `:build_path`, which is a path to folder where archive will be created.