### PR TITLE
Fixed `mkdir -p` for `build_path`.

### DIFF
--- a/lib/gym/generators/build_command_generator.rb
+++ b/lib/gym/generators/build_command_generator.rb
@@ -80,11 +80,12 @@ module Gym
 
       # The path where archive will be created
       def build_path
-        Gym.cache[:build_path] ||= Gym.config[:build_path]
         unless Gym.cache[:build_path]
-          day = Time.now.strftime("%F") # e.g. 2015-08-07
-
-          Gym.cache[:build_path] = File.expand_path("~/Library/Developer/Xcode/Archives/#{day}/")
+          Gym.cache[:build_path] = Gym.config[:build_path]
+          unless Gym.cache[:build_path]
+            day = Time.now.strftime("%F") # e.g. 2015-08-07
+            Gym.cache[:build_path] = File.expand_path("~/Library/Developer/Xcode/Archives/#{day}/")
+          end
           FileUtils.mkdir_p Gym.cache[:build_path]
         end
         Gym.cache[:build_path]


### PR DESCRIPTION
Hi,

I noticed that the `build_path` folder was not created by `gym` when `:build_path` parameter was passed. Right now current behaviour doesn't break anything because `export` action on `xcodebuild` automatically creates the folder. But if in the future someone wants to use this parameter, it would be nice to have this already done.

PS. Sorry that I didn't check this behaviour before :cry: 