### PR TITLE
Fix example use of --use_legacy_build_api flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ If you run into any issues, use the `verbose` mode to get more information
 
 In general, if you run into issues while exporting the archive, try using:
 
-    gym --use_legacy_build_api true
+    gym --use_legacy_build_api
 
 Set the right export method if you're not uploading to App Store or TestFlight:
 


### PR DESCRIPTION
Boolean command line flags do not take parameters, so removing it from this example will prevent users from learning a style that doesn't really work