### PR TITLE
adding option to just export ipa from archive_path

### DIFF
--- a/lib/gym/error_handler.rb
+++ b/lib/gym/error_handler.rb
@@ -99,7 +99,7 @@ module Gym
         print "For more information visit https://developer.apple.com/library/ios/technotes/tn2215/_index.html"
         print "Also, make sure to have a valid code signing identity and provisioning profile installed"
         print "Follow this guide to setup code signing https://github.com/fastlane/fastlane/blob/master/docs/CodeSigning.md"
-        print "If your intension was only to export an ipa be sure to provide a valid archive at the archive path."
+        print "If your intention was only to export an ipa be sure to provide a valid archive at the archive path."
         UI.user_error!("Archive invalid")
       end
 

--- a/lib/gym/error_handler.rb
+++ b/lib/gym/error_handler.rb
@@ -99,6 +99,7 @@ module Gym
         print "For more information visit https://developer.apple.com/library/ios/technotes/tn2215/_index.html"
         print "Also, make sure to have a valid code signing identity and provisioning profile installed"
         print "Follow this guide to setup code signing https://github.com/fastlane/fastlane/blob/master/docs/CodeSigning.md"
+        print "If your intension was only to export an ipa be sure to provide a valid archive at the archive path."
         UI.user_error!("Archive invalid")
       end
 

--- a/lib/gym/options.rb
+++ b/lib/gym/options.rb
@@ -122,6 +122,11 @@ module Gym
                                      conflict_block: proc do |value|
                                        UI.user_error!("'#{value.key}' must be false to use 'export_options'")
                                      end),
+        FastlaneCore::ConfigItem.new(key: :just_export,
+                                     env_name: "GYM_JUST_EXPORT",
+                                     description: "Just export ipa from archive_path. Do not build again. Default false",
+                                     is_string: false,
+                                     optional: true),
 
         # Very optional
         FastlaneCore::ConfigItem.new(key: :build_path,

--- a/lib/gym/options.rb
+++ b/lib/gym/options.rb
@@ -124,7 +124,7 @@ module Gym
                                      end),
         FastlaneCore::ConfigItem.new(key: :just_export,
                                      env_name: "GYM_JUST_EXPORT",
-                                     description: "Just export ipa from archive_path. Do not build again. Default false",
+                                     description: "Export ipa from previously build xarchive. Uses archive_path as source",
                                      is_string: false,
                                      optional: true),
 

--- a/lib/gym/options.rb
+++ b/lib/gym/options.rb
@@ -127,7 +127,6 @@ module Gym
                                      description: "Export ipa from previously build xarchive. Uses archive_path as source",
                                      is_string: false,
                                      optional: true),
-
         # Very optional
         FastlaneCore::ConfigItem.new(key: :build_path,
                                      env_name: "GYM_BUILD_PATH",

--- a/lib/gym/options.rb
+++ b/lib/gym/options.rb
@@ -122,8 +122,8 @@ module Gym
                                      conflict_block: proc do |value|
                                        UI.user_error!("'#{value.key}' must be false to use 'export_options'")
                                      end),
-        FastlaneCore::ConfigItem.new(key: :just_export,
-                                     env_name: "GYM_JUST_EXPORT",
+        FastlaneCore::ConfigItem.new(key: :skip_build_archive,
+                                     env_name: "GYM_SKIP_BUILD_ARCHIVE",
                                      description: "Export ipa from previously build xarchive. Uses archive_path as source",
                                      is_string: false,
                                      optional: true),

--- a/lib/gym/runner.rb
+++ b/lib/gym/runner.rb
@@ -7,9 +7,8 @@ module Gym
   class Runner
     # @return (String) The path to the resulting ipa
     def run
-      clear_old_files
-
       unless Gym.config[:just_export]
+        clear_old_files
         build_app
       end
       verify_archive

--- a/lib/gym/runner.rb
+++ b/lib/gym/runner.rb
@@ -7,7 +7,7 @@ module Gym
   class Runner
     # @return (String) The path to the resulting ipa
     def run
-      unless Gym.config[:just_export]
+      unless Gym.config[:skip_build_archive]
         clear_old_files
         build_app
       end

--- a/lib/gym/runner.rb
+++ b/lib/gym/runner.rb
@@ -9,7 +9,7 @@ module Gym
     def run
       clear_old_files
 
-      if !Gym.config[:just_export]
+      unless Gym.config[:just_export]
         build_app
       end
       verify_archive

--- a/lib/gym/runner.rb
+++ b/lib/gym/runner.rb
@@ -9,7 +9,9 @@ module Gym
     def run
       clear_old_files
 
-      build_app
+      if !Gym.config[:just_export]
+        build_app
+      end
       verify_archive
 
       FileUtils.mkdir_p(Gym.config[:output_directory])


### PR DESCRIPTION
Added an option to only export an ipa file from a xarchive.

For me it is required to export development, adhoc and appstore version of an build. This option enables me to skip two build processes and only export ipas from the same build archive.