### PR TITLE
Improve the speed of the Gym tests

### DIFF
--- a/spec/build_command_generator_spec.rb
+++ b/spec/build_command_generator_spec.rb
@@ -1,4 +1,13 @@
 describe Gym do
+  before(:all) do
+    options = { project: "./examples/standard/Example.xcodeproj" }
+    config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+    @project = FastlaneCore::Project.new(config)
+  end
+  before(:each) do
+    allow(Gym).to receive(:project).and_return(@project)
+  end
+
   describe Gym::BuildCommandGenerator do
     it "raises an exception when project path wasn't found" do
       expect do
@@ -13,7 +22,7 @@ describe Gym do
       xcargs = xcargs_hash.map do |k, v|
         "#{k.to_s.shellescape}=#{v.shellescape}"
       end.join ' '
-      options = { project: "./examples/standard/Example.xcodeproj", sdk: "9.0", xcargs: xcargs }
+      options = { project: "./examples/standard/Example.xcodeproj", sdk: "9.0", xcargs: xcargs, scheme: 'Example' }
       Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
 
       result = Gym::BuildCommandGenerator.generate
@@ -33,7 +42,7 @@ describe Gym do
 
     describe "Standard Example" do
       before do
-        options = { project: "./examples/standard/Example.xcodeproj" }
+        options = { project: "./examples/standard/Example.xcodeproj", scheme: 'Example' }
         Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
       end
 
@@ -65,7 +74,7 @@ describe Gym do
       end
 
       it "user provided #build_path" do
-        options = { project: "./examples/standard/Example.xcodeproj", build_path: "/tmp/my/build_path" }
+        options = { project: "./examples/standard/Example.xcodeproj", build_path: "/tmp/my/build_path", scheme: 'Example' }
         Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
         result = Gym::BuildCommandGenerator.build_path
         expect(result).to eq("/tmp/my/build_path")
@@ -78,7 +87,7 @@ describe Gym do
       end
 
       it "#buildlog_path is used when provided" do
-        options = { project: "./examples/standard/Example.xcodeproj", buildlog_path: "/tmp/my/path" }
+        options = { project: "./examples/standard/Example.xcodeproj", buildlog_path: "/tmp/my/path", scheme: 'Example' }
         Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
         result = Gym::BuildCommandGenerator.xcodebuild_log_path
         expect(result).to include("/tmp/my/path")
@@ -92,7 +101,7 @@ describe Gym do
 
     describe "Derived Data Example" do
       before do
-        options = { project: "./examples/standard/Example.xcodeproj", derived_data_path: "/tmp/my/derived_data" }
+        options = { project: "./examples/standard/Example.xcodeproj", derived_data_path: "/tmp/my/derived_data", scheme: 'Example' }
         Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
       end
 
@@ -118,7 +127,7 @@ describe Gym do
       it "uses the correct build command with the example project" do
         log_path = File.expand_path("~/Library/Logs/gym/ExampleProductName-Example.log")
 
-        options = { project: "./examples/standard/Example.xcodeproj", result_bundle: true }
+        options = { project: "./examples/standard/Example.xcodeproj", result_bundle: true, scheme: 'Example' }
         Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
 
         result = Gym::BuildCommandGenerator.generate

--- a/spec/gymfile_spec.rb
+++ b/spec/gymfile_spec.rb
@@ -1,11 +1,12 @@
 describe Gym do
+  before(:all) do
+    options = { project: "./examples/multipleSchemes/Example.xcodeproj" }
+    @config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+    @project = FastlaneCore::Project.new(@config)
+  end
+
   describe "Project with multiple Schemes and Gymfile" do
-    before do
-      options = { project: "./examples/multipleSchemes/Example.xcodeproj" }
-      Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options,
-                                                      options)
-      @project = FastlaneCore::Project.new(Gym.config)
-    end
+    before(:each) { Gym.config = @config }
 
     it "#schemes returns all available schemes" do
       expect(@project.schemes).to eq(["Example", "ExampleTests"])

--- a/spec/package_command_generator_legacy_spec.rb
+++ b/spec/package_command_generator_legacy_spec.rb
@@ -1,4 +1,13 @@
 describe Gym do
+  before(:all) do
+    options = { project: "./examples/standard/Example.xcodeproj" }
+    config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+    @project = FastlaneCore::Project.new(config)
+  end
+  before(:each) do
+    allow(Gym).to receive(:project).and_return(@project)
+  end
+
   describe Gym::PackageCommandGeneratorLegacy do
     it "works with the example project with no additional parameters" do
       options = { project: "./examples/standard/Example.xcodeproj" }

--- a/spec/package_command_generator_xcode7_spec.rb
+++ b/spec/package_command_generator_xcode7_spec.rb
@@ -1,4 +1,13 @@
 describe Gym do
+  before(:all) do
+    options = { project: "./examples/standard/Example.xcodeproj" }
+    config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+    @project = FastlaneCore::Project.new(config)
+  end
+  before(:each) do
+    allow(Gym).to receive(:project).and_return(@project)
+  end
+
   describe Gym::PackageCommandGeneratorXcode7 do
     it "works with the example project with no additional parameters" do
       options = { project: "./examples/standard/Example.xcodeproj" }
@@ -21,7 +30,6 @@ describe Gym do
       result = Gym::PackageCommandGeneratorXcode7.generate
       config_path = Gym::PackageCommandGeneratorXcode7.config_path
 
-      require 'plist'
       expect(Plist.parse_xml(config_path)).to eq({
         'method' => "app-store",
         'uploadBitcode' => false,
@@ -36,7 +44,6 @@ describe Gym do
       result = Gym::PackageCommandGeneratorXcode7.generate
       config_path = Gym::PackageCommandGeneratorXcode7.config_path
 
-      require 'plist'
       expect(Plist.parse_xml(config_path)).to eq({
         'embedOnDemandResourcesAssetPacksInBundle' => true,
         'manifest' => {
@@ -66,7 +73,6 @@ describe Gym do
       result = Gym::PackageCommandGeneratorXcode7.generate
       config_path = Gym::PackageCommandGeneratorXcode7.config_path
 
-      require 'plist'
       expect(Plist.parse_xml(config_path)).to eq({
         'embedOnDemandResourcesAssetPacksInBundle' => true,
         'manifest' => {
@@ -106,7 +112,6 @@ describe Gym do
       result = Gym::PackageCommandGeneratorXcode7.generate
       config_path = Gym::PackageCommandGeneratorXcode7.config_path
 
-      require 'plist'
       expect(Plist.parse_xml(config_path)).to eq({
         'embedOnDemandResourcesAssetPacksInBundle' => false,
         'manifest' => {
@@ -128,7 +133,6 @@ describe Gym do
       result = Gym::PackageCommandGeneratorXcode7.generate
       config_path = Gym::PackageCommandGeneratorXcode7.config_path
 
-      require 'plist'
       expect(Plist.parse_xml(config_path)).to eq({
         'method' => "ad-hoc"
       })


### PR DESCRIPTION
Makes the gym tests much faster (26s -> 7s on my machine). It does this by limiting the number of times `FastlaneCore::Project` objects are instantiated and thus need to shell out to Xcode tools. A future improvement could be to separate the concern of testing `Project` class interactions with Xcode tools from downstream consumers like gym.

This caching is performed at the spec file level, so it depends on each spec file running against roughly the same project configuration for all of its tests. All of ours basically do! Also, the more test examples exist per file, the larger the savings.

This caching increases the complexity of a somewhat complicated code area by breaking some of the `Configuration` object sharing that happens internally so that side-effecting changes between `Project` and `gym`'s config are shared. I'd consider it to be future work to try to reduce the tight coupling between `Project` objects and a tool's shared config object.